### PR TITLE
[Feature] Add Event handler framework with decorators and filtering

### DIFF
--- a/qube/events/clients.py
+++ b/qube/events/clients.py
@@ -1,12 +1,12 @@
 import paho.mqtt.client as mqtt
 from datetime import UTC, datetime
-from functools import wraps
 from typing import Callable, Dict, Optional
 
 from qube.events.exceptions import MessageHandlingError, SubscriptionError
+from qube.events.handlers import QueueHandler, QueuingSystemResetHandler, TicketHandler
 
 
-class MQTTClient:
+class MQTTClient(TicketHandler, QueuingSystemResetHandler, QueueHandler):
     """
     A versatile MQTT client for connecting to an MQTT broker, subscribing to topics,
     and handling message events with user-defined handlers.
@@ -15,23 +15,28 @@ class MQTTClient:
     DEFAULT_BROKER_URL = "mqtt.qube.q-better.com"
     DEFAULT_BROKER_PORT = 443
 
-    def __init__(self, api_key: str, broker_url: str = None, broker_port: int = None):
+    def __init__(self, api_key: str, location_id: id, broker_url: str = None, broker_port: int = None):
         """
         Initializes and connects the MQTT client.
 
         Args:
             api_key (str): API key for client authentication.
+            location_id (int): Location ID to use in requests.
             broker_url (str, optional): URL of the MQTT broker. Defaults to DEFAULT_BROKER_URL.
             broker_port (int, optional): Port of the MQTT broker. Defaults to DEFAULT_BROKER_PORT.
         Raises:
             ConnectionError: If unable to connect to the broker.
         """
 
+        super().__init__()
         self.broker_url = broker_url or self.DEFAULT_BROKER_URL
         self.broker_port = broker_port or self.DEFAULT_BROKER_PORT
+        self.location_id = location_id
 
         self.client = mqtt.Client()
-        self.message_handlers: Dict[str, Callable[[bytes], None]] = {}  # Maps topics to handler functions
+
+        self.message_handlers: Dict[str, list[Callable[[bytes], None]]] = {}  # Maps topics to handler functions
+        self._subscribed_topics = set()  # Tracks subscribed topics
         self._created_at = datetime.now(UTC)
 
         # Set the username for authentication
@@ -64,23 +69,28 @@ class MQTTClient:
 
     def _on_connect(self, client: mqtt.Client, userdata: Optional[object], flags: dict, rc: int) -> None:
         """
-        Callback triggered upon connecting to the MQTT broker. Subscribes to all topics
-        that have registered handlers.
+        Callback triggered when the client successfully connects to the MQTT broker.
+        Subscribes to all topics that have registered handlers.
 
         Args:
             client (mqtt.Client): The MQTT client instance.
-            userdata (Optional[object]): Optional user data (not used).
-            flags (dict): Response flags from the broker.
-            rc (int): Connection result (0 indicates success).
+            userdata (Optional[object]): Optional user data (not used in this implementation).
+            flags (dict): A dictionary of response flags from the broker.
+            rc (int): The connection result code. A value of 0 indicates success, while any other value indicates failure.
 
         Raises:
-            ConnectionError: If the client fails to connect successfully.
-            SubscriptionError: If subscribing to any topic fails.
+            ConnectionError: If the connection to the broker fails (rc != 0).
+            SubscriptionError: If subscribing to any topic fails after a successful connection.
+
+        Notes:
+            - The method subscribes to topics only if the connection is successful (rc == 0).
+            - It attempts to subscribe to each topic stored in `_subscribed_topics` that has a registered handler.
         """
         if rc == 0:
-            for topic in self.message_handlers:
+            for topic in self._subscribed_topics:
                 try:
-                    self.client.subscribe(topic)
+                    if topic not in self.message_handlers:
+                        client.subscribe(topic)
                 except Exception as e:
                     raise SubscriptionError(f"Failed to subscribe to topic '{topic}': {e}")
         else:
@@ -99,31 +109,59 @@ class MQTTClient:
         Raises:
             MessageHandlingError: If the handler for a topic fails.
         """
-        for topic, handler in self.message_handlers.items():
+        for topic, handlers in self.message_handlers.items():
             if mqtt.topic_matches_sub(topic, msg.topic):
-                try:
-                    handler(msg.payload)
-                except Exception as e:
-                    raise MessageHandlingError(f"Error handling message for topic '{topic}': {e}")
+                for handler in handlers:
+                    try:
+                        handler(msg.payload)
+                    except Exception as e:
+                        raise MessageHandlingError(f"Error in handler for topic '{topic}': {e}")
 
-    def add_handler(self, topic: str, handler: Callable[[bytes], None]) -> None:
+    def subscribe_to_topic(self, topic: str, handler: Callable[[bytes], None]) -> None:
         """
-        Registers a handler function for a specific MQTT topic. If already connected,
-        immediately subscribes to the topic.
+        Subscribes to an MQTT topic and registers a handler function to process incoming messages.
 
         Args:
             topic (str): The MQTT topic to subscribe to.
-            handler (Callable[[bytes], None]): A function that processes the message payload.
+            handler (Callable[[bytes], None]): A function that processes messages for this topic.
+                It must accept a single argument of type `bytes` (the message payload).
 
         Raises:
-            SubscriptionError: If the subscription fails.
+            SubscriptionError: If subscribing to the topic fails.
+
+        Notes:
+            - The same handler will not be registered more than once for the same topic.
+            - A topic is subscribed to only once, even if multiple handlers are added.
         """
-        self.message_handlers[topic] = handler
-        if self.client.is_connected():
+        if topic not in self.message_handlers:
+            self.message_handlers[topic] = []
+
+        if handler not in self.message_handlers[topic]:
+            self.message_handlers[topic].append(handler)
+            if topic not in self._subscribed_topics:
+                try:
+                    self.client.subscribe(topic)
+                    self._subscribed_topics.add(topic)
+                except Exception as e:
+                    raise SubscriptionError(f"Failed to subscribe to topic '{topic}': {e}")
+
+    def unsubscribe_from_topic(self, topic: str) -> None:
+        """
+        Unsubscribes from an MQTT topic and removes its handler.
+        """
+        if topic in self._subscribed_topics:
             try:
-                self.client.subscribe(topic)
+                self.client.unsubscribe(topic)
+                self._subscribed_topics.remove(topic)
+                self.message_handlers.pop(topic, None)
             except Exception as e:
-                raise SubscriptionError(f"Failed to subscribe to topic '{topic}': {e}")
+                raise SubscriptionError(f"Failed to unsubscribe from topic '{topic}': {e}")
+
+    def list_subscribed_topics(self) -> list:
+        """
+        Lists all currently subscribed topics.
+        """
+        return list(self._subscribed_topics)
 
     def age(self) -> int:
         """

--- a/qube/events/exceptions.py
+++ b/qube/events/exceptions.py
@@ -11,3 +11,28 @@ class SubscriptionError(MQTTClientError):
 class MessageHandlingError(MQTTClientError):
     """Raised when an error occurs while handling an MQTT message."""
     pass
+
+
+class PayloadError(MQTTClientError):
+    """Base class for payload-related errors."""
+    pass
+
+
+class PayloadFormatError(PayloadError):
+    """Raised when there is an issue with the format of the message payload."""
+    pass
+
+
+class PayloadTypeError(PayloadError):
+    """Raised when the payload type does not match the expected type."""
+    pass
+
+
+class HandlerRegistrationError(MQTTClientError):
+    """Raised when there is an issue registering an MQTT handler."""
+    pass
+
+
+class InvalidTicketHandlerArgumentsError(MQTTClientError):
+    """Raised when both or neither 'queue_id' and 'counter_id' are provided."""
+    pass

--- a/qube/events/handlers.py
+++ b/qube/events/handlers.py
@@ -1,0 +1,226 @@
+import json
+from abc import ABC, abstractmethod
+from functools import wraps
+from typing import List, Type, Union, Optional, Callable
+
+from qube.events.exceptions import HandlerRegistrationError, PayloadFormatError, PayloadTypeError, \
+    InvalidTicketHandlerArgumentsError
+from qube.events.types import Ticket, QueuingSystemReset, QueueWithAverageWaitingTime, QueueWithWaitingTickets, AnsweringTicket
+
+
+class MQTTEventHandlerBase(ABC):
+
+    def __init__(self):
+        self.message_handlers = None
+
+    def add_mqtt_handler(
+        self,
+        topic: str,
+        payload_type: Optional[Union[List[Type], Type]] = None,
+        payload_filter: Optional[Callable] = None
+    ):
+        """
+        Registers an MQTT handler for a given topic and message type.
+
+        Args:
+            topic (str): The MQTT topic to subscribe to.
+            payload_type (Type or List[Type]): Expected data type for decoding the message payload.
+                If a list type is specified, the payload is expected to be a list of dictionaries.
+            payload_filter (Callable, optional): A function to filter the payload before passing it to the handler.
+        """
+
+        def decorator(func):
+
+            @wraps(func)
+            def wrapper(payload):
+                msg = self._decode_payload(payload, payload_type)
+                if msg is not None:
+                    if payload_filter:
+                        msg = payload_filter(msg)
+                    return func(msg)
+
+            # Check if the exact handler is already registered for the topic
+            existing_handlers = self.message_handlers.get(topic, [])
+            for existing_handler in existing_handlers:
+                if getattr(existing_handler, '__wrapped__', None) == func:
+                    raise HandlerRegistrationError(
+                        f"Handler '{func.__name__}' is already registered for topic '{topic}'."
+                    )
+
+            try:
+                # Register the handler
+                self.subscribe_to_topic(topic, wrapper)
+            except Exception as e:
+                raise HandlerRegistrationError(f"Failed to register handler for topic '{topic}': {e}")
+
+            return wrapper
+
+        return decorator
+
+    @staticmethod
+    def _decode_payload(payload: bytes, payload_type: Union[Type, List[Type]]):
+        """
+        Decodes a JSON payload into a specified message type.
+
+        Args:
+            payload (bytes): The raw message payload.
+            payload_type (Type or List[Type]): The type(s) to decode the payload into.
+
+        Returns:
+            An instance of the specified type or a list of instances if the payload_type is a list.
+            None if decoding fails.
+        """
+        try:
+            data = json.loads(payload.decode('utf-8'))
+
+            # Check if we expect a list of items
+            if isinstance(payload_type, list) and payload_type:
+                item_type = payload_type[0]
+                if isinstance(data, list):
+                    return [item_type(**item) for item in data]
+                else:
+                    raise PayloadFormatError("Expected payload to be a list of dictionaries.")
+
+            # For a single item
+            return payload_type(**data)
+        except json.JSONDecodeError as e:
+            raise PayloadFormatError("Invalid JSON payload.") from e
+        except TypeError as e:
+            raise PayloadTypeError(f"Type mismatch in payload for type '{payload_type}': {e}") from e
+
+    @abstractmethod
+    def subscribe_to_topic(self, topic: str, handler) -> None:
+        pass
+
+
+class QueuingSystemResetHandler(MQTTEventHandlerBase, ABC):
+    """
+    Handles MQTT events related to queuing system resets.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.location_id = None
+
+    def on_queuing_system_resets_created(self):
+        """
+        Registers a handler for the 'created' event of queuing system resets.
+
+        Returns:
+            The decorator for the handler function.
+        """
+        topic = f"locations/{self.location_id}/queuing-system-resets/created"
+        return self.add_mqtt_handler(topic, QueuingSystemReset)
+
+
+class QueueHandler(MQTTEventHandlerBase, ABC):
+    """
+    Handles MQTT events related to queues.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.location_id = None
+
+    def on_queues_changed_average_waiting_time(self, queue_id: Optional[int] = None):
+        """
+        Registers a handler for the 'changed average waiting time' event of queues.
+
+        Args:
+            queue_id (Optional[int]): The ID of the queue to filter events for. If not provided, all queues are handled.
+
+        Returns:
+            The decorator for the handler function.
+        """
+        topic = f"locations/{self.location_id}/queues/changed-average-waiting-time"
+        return self.add_mqtt_handler(topic, [QueueWithAverageWaitingTime], self._get_queue_filter(queue_id))
+
+    def on_queues_changed_waiting_number(self, queue_id: Optional[int] = None):
+        """
+        Registers a handler for the 'changed waiting number' event of queues.
+
+        Args:
+            queue_id (Optional[int]): The ID of the queue to filter events for. If not provided, all queues are handled.
+
+        Returns:
+            The decorator for the handler function.
+        """
+        topic = f"locations/{self.location_id}/queues/changed-waiting-number"
+        return self.add_mqtt_handler(topic, [QueueWithWaitingTickets], self._get_queue_filter(queue_id))
+
+    @staticmethod
+    def _get_queue_filter(queue_id: Optional[int] = None):
+        """
+        Returns a filter function that filters results based on the provided queue_id.
+
+        Args:
+            queue_id (Optional[int]): The ID of the queue to filter by.
+
+        Returns:
+            A function that filters the results based on the queue_id.
+        """
+
+        def payload_filter(results):
+            """Filters the payload based on queue_id, returning the matching item or all results."""
+            if queue_id is not None:
+                for result in results:
+                    if result.queue.id == queue_id:
+                        return result
+                return None
+            return results
+
+        return payload_filter
+
+
+class TicketHandler(MQTTEventHandlerBase, ABC):
+    """
+    Handles MQTT events related to tickets.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.location_id = None
+
+    def on_ticket_generated(self):
+        """
+        Registers a handler for the 'generated' event of tickets.
+
+        Returns:
+            The decorator for the handler function.
+        """
+        topic = f"locations/{self.location_id}/tickets/generated"
+        return self.add_mqtt_handler(topic, Ticket)
+
+    def on_ticket_called(
+        self,
+        queue_id: Optional[int] = None,
+        counter_id: Optional[int] = None,
+    ):
+        """
+        Registers a handler for the 'called' event of tickets.
+
+        Args:
+            queue_id (int, optional): The ID of the queue to filter by.
+            counter_id (int, optional): The ID of the counter to filter by.
+
+        Returns:
+            The decorator for the handler function.
+
+        Raises:
+            InvalidTicketHandlerArgumentsError: If both or neither `queue_id` and `counter_id` are provided.
+        """
+        # Check that exactly one of the arguments is provided
+        if (queue_id is not None) and (counter_id is not None):
+            raise InvalidTicketHandlerArgumentsError(
+                "You can only provide one of 'queue_id' or 'counter_id', not both."
+            )
+        if (queue_id is None) and (counter_id is None):
+            raise InvalidTicketHandlerArgumentsError("You must provide exactly one of 'queue_id' or 'counter_id'.")
+
+        topic = f"locations/{self.location_id}"
+        if queue_id is not None:
+            topic += f"/queues/{queue_id}/tickets/called"
+        else:
+            topic += f"/counters/{counter_id}/tickets/called"
+
+        return self.add_mqtt_handler(topic, AnsweringTicket)

--- a/qube/events/tests/test_mqtt_event_handler_base.py
+++ b/qube/events/tests/test_mqtt_event_handler_base.py
@@ -1,0 +1,157 @@
+import unittest
+from unittest.mock import MagicMock
+
+from qube.events.exceptions import HandlerRegistrationError, PayloadFormatError, PayloadTypeError
+from qube.events.handlers import MQTTEventHandlerBase
+
+
+class MockPayload:
+    """
+    A mock payload class for testing purposes.
+    """
+
+    def __init__(self, field1: str, field2: int):
+        self.field1 = field1
+        self.field2 = field2
+
+
+class MockPayloadListItem:
+    """
+    A mock payload list item class for testing purposes.
+    """
+
+    def __init__(self, id: int):
+        self.id = id
+
+
+class TestMQTTEventHandlerBase(unittest.TestCase):
+    """
+    Unit tests for the MQTTEventHandlerBase class.
+    """
+
+    def setUp(self):
+
+        class TestHandler(MQTTEventHandlerBase):
+            """
+            A test handler class inheriting from MQTTEventHandlerBase.
+            """
+
+            def __init__(self):
+                super().__init__()
+                self.message_handlers = {}
+
+            def subscribe_to_topic(self, topic: str, handler) -> None:
+                """
+                Subscribe a handler to a specific topic.
+
+                Args:
+                    topic (str): The topic to subscribe to.
+                    handler: The handler function to be called when a message is received on the topic.
+                """
+                if topic in self.message_handlers:
+                    self.message_handlers[topic].append(handler)
+                else:
+                    self.message_handlers[topic] = [handler]
+
+        self.handler = TestHandler()
+
+    def test_add_handler_registers_handler(self):
+        """
+        Test that adding a handler registers it correctly.
+        """
+
+        def mock_handler(msg):
+            pass
+
+        self.handler.add_mqtt_handler("test/topic")(mock_handler)
+        self.assertIn("test/topic", self.handler.message_handlers)
+        self.assertEqual(len(self.handler.message_handlers["test/topic"]), 1)
+
+    def test_add_handler_duplicate_registration_raises_error(self):
+        """
+        Test that adding a duplicate handler raises a HandlerRegistrationError.
+        """
+
+        def mock_handler(msg):
+            pass
+
+        self.handler.add_mqtt_handler("test/topic")(mock_handler)
+        with self.assertRaises(HandlerRegistrationError):
+            self.handler.add_mqtt_handler("test/topic")(mock_handler)
+
+    def test_decode_payload_valid_data(self):
+        """
+        Test that decoding a valid payload returns the correct object.
+        """
+        payload = b'{"field1": "test", "field2": 123}'
+        result = self.handler._decode_payload(payload, MockPayload)
+        self.assertIsInstance(result, MockPayload)
+        self.assertEqual(result.field1, "test")
+        self.assertEqual(result.field2, 123)
+
+    def test_decode_payload_invalid_json_raises_error(self):
+        """
+        Test that decoding an invalid JSON payload raises a PayloadFormatError.
+        """
+        payload = b'invalid-json'
+        with self.assertRaises(PayloadFormatError):
+            self.handler._decode_payload(payload, MockPayload)
+
+    def test_decode_payload_type_mismatch_raises_error(self):
+        """
+        Test that decoding a payload with a type mismatch raises a PayloadTypeError.
+        """
+        payload = b'{"field1": "test", "field_unknown": "not-an-int"}'
+        with self.assertRaises(PayloadTypeError):
+            self.handler._decode_payload(payload, MockPayload)
+
+    def test_decode_payload_list_valid_data(self):
+        """
+        Test that decoding a valid list payload returns the correct list of objects.
+        """
+        payload = b'[{"id": 1}, {"id": 2}]'
+        result = self.handler._decode_payload(payload, [MockPayloadListItem])
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].id, 1)
+        self.assertEqual(result[1].id, 2)
+
+    def test_decode_payload_list_invalid_data_raises_error(self):
+        """
+        Test that decoding an invalid list payload raises a PayloadFormatError.
+        """
+        payload = b'{"id": 1}'  # Not a list
+        with self.assertRaises(PayloadFormatError):
+            self.handler._decode_payload(payload, [MockPayloadListItem])
+
+    def test_handler_executes_with_valid_payload(self):
+        """
+        Test that a handler executes correctly with a valid payload.
+        """
+        mock_handler = MagicMock()
+        self.handler.add_mqtt_handler("test/topic", MockPayload)(mock_handler)
+        payload = b'{"field1": "test", "field2": 123}'
+        registered_handler = self.handler.message_handlers["test/topic"][0]
+        registered_handler(payload)
+        mock_handler.assert_called_once()
+        mock_handler.assert_called_with(mock_handler.call_args[0][0])
+        self.assertIsInstance(mock_handler.call_args[0][0], MockPayload)
+
+    def test_handler_with_filter(self):
+        """
+        Test that a handler with a filter function processes the payload correctly.
+        """
+
+        def filter_func(payload):
+            return {
+                "field1": payload.field1.upper(),
+                "field2": payload.field2
+            }
+
+        mock_handler = MagicMock()
+        self.handler.add_mqtt_handler("test/topic", MockPayload, filter_func)(mock_handler)
+        payload = b'{"field1": "test", "field2": 123}'
+        registered_handler = self.handler.message_handlers["test/topic"][0]
+        registered_handler(payload)
+        mock_handler.assert_called_once()
+        self.assertEqual(mock_handler.call_args[0][0].get('field1'), "TEST")

--- a/qube/events/tests/test_queue_handler.py
+++ b/qube/events/tests/test_queue_handler.py
@@ -1,0 +1,118 @@
+import unittest
+from unittest.mock import MagicMock, ANY, Mock
+
+from qube.events.handlers import QueueHandler
+from qube.events.types import QueueWithAverageWaitingTime, QueueWithWaitingTickets, QueueGeneralDetails
+
+
+class ConcreteQueueHandler(QueueHandler):
+
+    def subscribe_to_topic(self, topic: str, handler: Mock):
+        # Mock implementation to satisfy abstract class
+        pass
+
+
+class TestQueueHandler(unittest.TestCase):
+
+    def setUp(self):
+        self.handler = ConcreteQueueHandler()
+        self.handler.location_id = 1  # dummy location ID
+
+    def test_on_queues_changed_average_waiting_time(self):
+        # Mock the add_mqtt_handler method to prevent actual MQTT handling
+        self.handler.add_mqtt_handler = MagicMock(return_value="Handler registered")
+
+        # Call the method with queue_id=5
+        result = self.handler.on_queues_changed_average_waiting_time(queue_id=5)
+
+        # Verify add_mqtt_handler is called with correct parameters
+        self.handler.add_mqtt_handler.assert_called_once_with(
+            "locations/1/queues/changed-average-waiting-time",
+            [QueueWithAverageWaitingTime],
+            ANY  # Filter function
+        )
+
+        # Extract the filter function passed to add_mqtt_handler
+        filter_function = self.handler.add_mqtt_handler.call_args[0][2]
+
+        # Test the filter function by calling it with mock data
+        mock_data = [
+            MagicMock(
+                queue=QueueGeneralDetails(
+                    id=5,
+                    tag="primaryQueue",
+                    name="Primary Service Queue",
+                    kpi_wait_count=5,
+                    kpi_wait_time=10,
+                    kpi_service_time=15
+                )
+            ),  # This should match
+            MagicMock(
+                queue=QueueGeneralDetails(
+                    id=6,
+                    tag="primaryQueue",
+                    name="Primary Service Queue",
+                    kpi_wait_count=5,
+                    kpi_wait_time=10,
+                    kpi_service_time=15
+                )
+            ),  # This should not match
+        ]
+
+        # Apply the filter function to the mock data
+        filtered_data = filter_function(mock_data)
+
+        # Check if the filter function behaves as expected (only the item with id 5 should be returned)
+        self.assertEqual(filtered_data, mock_data[0])
+
+        # Check the result of the method
+        self.assertEqual(result, "Handler registered")
+
+    def test_on_queues_changed_waiting_number(self):
+        # Mock the add_mqtt_handler method to prevent actual MQTT handling
+        self.handler.add_mqtt_handler = MagicMock(return_value="Handler registered")
+
+        # Call the method with queue_id=10
+        result = self.handler.on_queues_changed_waiting_number(queue_id=10)
+
+        # Verify add_mqtt_handler is called with correct parameters
+        self.handler.add_mqtt_handler.assert_called_once_with(
+            "locations/1/queues/changed-waiting-number",
+            [QueueWithWaitingTickets],
+            ANY  # Filter function
+        )
+
+        # Check the result of the method
+        self.assertEqual(result, "Handler registered")
+
+    def test_get_queue_filter(self):
+        # Create a filter function for queue_id=3
+        filter_func = self.handler._get_queue_filter(queue_id=2)
+
+        queue1 = QueueGeneralDetails(
+            id=1,
+            tag="primaryQueue",
+            name="Primary Service Queue",
+            kpi_wait_count=5,
+            kpi_wait_time=10,
+            kpi_service_time=15
+        )
+        queue2 = QueueGeneralDetails(
+            id=2,
+            tag="secondaryQueue",
+            name="Secondary Service Queue",
+            kpi_wait_count=10,
+            kpi_wait_time=20,
+            kpi_service_time=25
+        )
+
+        result1 = QueueWithWaitingTickets(queue=queue1, waiting_tickets=5)
+        result2 = QueueWithWaitingTickets(queue=queue2, waiting_tickets=10)
+
+        results = [result1, result2]
+
+        # Apply the filter function to the mock data
+        filtered_results = filter_func(results)
+
+        # Assert that only the item with id=2 is returned
+        self.assertEqual(filtered_results, result2)

--- a/qube/events/tests/test_queue_handler_decorator.py
+++ b/qube/events/tests/test_queue_handler_decorator.py
@@ -1,0 +1,158 @@
+import pytest
+import json
+from unittest.mock import Mock
+from qube.events.types import QueueWithAverageWaitingTime, QueueWithWaitingTickets, QueueGeneralDetails
+
+
+class TestQueueHandlerDecorators:
+    """
+    Test suite for the QueueHandler decorators using the mqtt_client fixture.
+    """
+
+    @pytest.fixture
+    def mqtt_client(self):
+        """
+        Fixture to create an instance of MQTTClient.
+        """
+        from qube.events.clients import MQTTClient
+        return MQTTClient(api_key="dummy_api_key", location_id=1)
+
+    def simulate_mqtt_message(self, mqtt_client, topic, payload):
+        """
+        Helper method to simulate an MQTT message.
+
+        Args:
+            mqtt_client (MQTTClient): The MQTT client instance.
+            topic (str): The MQTT topic.
+            payload (dict): The payload for the MQTT message.
+        """
+        mqtt_client._on_message(
+            mqtt_client.client, None, Mock(topic=topic, payload=json.dumps(payload).encode('utf-8'))
+        )
+
+    def test_on_queues_changed_average_waiting_time_specific_queue(self, mqtt_client):
+        """
+        Test the on_queues_changed_average_waiting_time decorator for a specific queue ID.
+        """
+        handler_mock = Mock()
+
+        payload = {
+            "queue": {
+                "id": 42,
+                "tag": "A",
+                "name": "Main Queue",
+                "kpi_wait_count": 5,
+                "kpi_wait_time": 10,
+                "kpi_service_time": 15
+            },
+            "average_waiting_time": 5
+        }
+
+        @mqtt_client.on_queues_changed_average_waiting_time(queue_id=42)
+        def handle(msg):
+            handler_mock(msg)
+
+        # Simulate MQTT message
+        topic = "locations/1/queues/changed-average-waiting-time"
+        self.simulate_mqtt_message(mqtt_client, topic, [payload])
+
+        handler_mock.assert_called_once_with(QueueWithAverageWaitingTime(**payload))
+
+    def test_on_queues_changed_average_waiting_time_all_queues(self, mqtt_client):
+        """
+        Test the on_queues_changed_average_waiting_time decorator for all queues.
+        """
+        handler_mock = Mock()
+        payload = {
+            "queue": {
+                "id": 42,
+                "tag": "A",
+                "name": "Main Queue",
+                "kpi_wait_count": 5,
+                "kpi_wait_time": 10,
+                "kpi_service_time": 15
+            },
+            "average_waiting_time": 5
+        }
+
+        @mqtt_client.on_queues_changed_average_waiting_time()
+        def handle(msg):
+            handler_mock(msg)
+
+        # Simulate MQTT message
+        topic = "locations/1/queues/changed-average-waiting-time"
+        self.simulate_mqtt_message(mqtt_client, topic, [payload])
+
+        handler_mock.assert_called_once_with([QueueWithAverageWaitingTime(**payload)])
+
+    def test_on_queues_changed_waiting_number_specific_queue(self, mqtt_client):
+        """
+        Test the on_queues_changed_waiting_number decorator for a specific queue ID.
+        """
+        handler_mock = Mock()
+        payload = {
+            "queue": {
+                "id": 99,
+                "tag": "B",
+                "name": "VIP Queue"
+            },
+            "waiting_tickets": 10
+        }
+
+        @mqtt_client.on_queues_changed_waiting_number(queue_id=99)
+        def handle(msg):
+            handler_mock(msg)
+
+        # Simulate MQTT message
+        topic = "locations/1/queues/changed-waiting-number"
+        self.simulate_mqtt_message(mqtt_client, topic, [payload])
+
+        handler_mock.assert_called_once_with(QueueWithWaitingTickets(**payload))
+
+    def test_on_queues_changed_waiting_number_all_queues(self, mqtt_client):
+        """
+        Test the on_queues_changed_waiting_number decorator for all queues.
+        """
+        handler_mock = Mock()
+        payload = {
+            "queue": {
+                "id": 99,
+                "tag": "B",
+                "name": "VIP Queue"
+            },
+            "waiting_tickets": 10
+        }
+
+        @mqtt_client.on_queues_changed_waiting_number()
+        def handle(msg):
+            handler_mock(msg)
+
+        # Simulate MQTT message
+        topic = "locations/1/queues/changed-waiting-number"
+        self.simulate_mqtt_message(mqtt_client, topic, [payload])
+
+        handler_mock.assert_called_once_with([QueueWithWaitingTickets(**payload)])
+
+    def test_on_queues_changed_average_waiting_time_invalid_queue(self, mqtt_client):
+        """
+        Test the on_queues_changed_average_waiting_time decorator with a non-matching queue ID.
+        """
+        handler_mock = Mock()
+        payload = {
+            "queue": {
+                "id": 1,
+                "tag": "C",
+                "name": "Non-matching Queue"
+            },
+            "average_waiting_time": 10
+        }
+
+        @mqtt_client.on_queues_changed_average_waiting_time(queue_id=42)
+        def handle(msg):
+            handler_mock(msg)
+
+        # Simulate MQTT message
+        topic = "locations/1/queues/changed-average-waiting-time"
+        self.simulate_mqtt_message(mqtt_client, topic, [payload])
+
+        handler_mock.assert_called_once_with(None)

--- a/qube/events/tests/test_queuing_system_reset_decorator.py
+++ b/qube/events/tests/test_queuing_system_reset_decorator.py
@@ -1,0 +1,52 @@
+import pytest
+import json
+from unittest.mock import Mock
+from qube.events.types import QueuingSystemReset
+
+
+class TestQueuingSystemResetDecorator:
+    """
+    Test suite for the QueuingSystemResetHandler decorators.
+    """
+
+    @pytest.fixture
+    def mqtt_client(self):
+        """
+        Fixture to create an instance of MQTTClient.
+        """
+        from qube.events.clients import MQTTClient
+        return MQTTClient(api_key="dummy_api_key", location_id=1)
+
+    def simulate_mqtt_message(self, mqtt_client, topic, payload):
+        """
+        Helper method to simulate an MQTT message.
+
+        Args:
+            mqtt_client (MQTTClient): The MQTT client instance.
+            topic (str): The MQTT topic.
+            payload (dict): The payload for the MQTT message.
+        """
+        mqtt_client._on_message(
+            mqtt_client.client, None, Mock(topic=topic, payload=json.dumps(payload).encode('utf-8'))
+        )
+
+    def test_on_queuing_system_resets_created(self, mqtt_client):
+        """
+        Test the on_queuing_system_resets_created decorator.
+        """
+        handler_mock = Mock()
+        payload = {
+            "id": 123,
+            "created_at": "2024-11-25T12:00:00Z",
+            "location": 1
+        }
+
+        @mqtt_client.on_queuing_system_resets_created()
+        def handle(msg):
+            handler_mock(msg)
+
+        # Simulate MQTT message
+        topic = "locations/1/queuing-system-resets/created"
+        self.simulate_mqtt_message(mqtt_client, topic, payload)
+
+        handler_mock.assert_called_once_with(QueuingSystemReset(**payload))

--- a/qube/events/tests/test_queuing_system_reset_handler.py
+++ b/qube/events/tests/test_queuing_system_reset_handler.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import MagicMock, Mock
+
+from qube.events.handlers import QueuingSystemResetHandler
+from qube.events.types import QueuingSystemReset
+
+
+# Concrete subclass for testing purposes
+class ConcreteQueuingSystemResetHandler(QueuingSystemResetHandler):
+
+    def subscribe_to_topic(self, topic: str, handler: Mock):
+        pass
+
+
+class TestQueuingSystemResetHandler(unittest.TestCase):
+
+    def setUp(self):
+        self.handler = ConcreteQueuingSystemResetHandler()
+        self.handler.location_id = 1  # dummy location ID
+
+    def test_on_queuing_system_resets_created(self):
+        # Mock the add_mqtt_handler method to prevent actual MQTT handling
+        self.handler.add_mqtt_handler = MagicMock(return_value="Handler registered")
+
+        result = self.handler.on_queuing_system_resets_created()
+
+        self.handler.add_mqtt_handler.assert_called_once_with(
+            "locations/1/queuing-system-resets/created", QueuingSystemReset
+        )
+        self.assertEqual(result, "Handler registered")

--- a/qube/events/tests/test_ticket_handler.py
+++ b/qube/events/tests/test_ticket_handler.py
@@ -1,0 +1,42 @@
+from unittest.mock import Mock
+import pytest
+
+from qube.events.exceptions import InvalidTicketHandlerArgumentsError
+from qube.events.handlers import TicketHandler
+
+
+# Concrete subclass for testing purposes
+class ConcreteTicketHandler(TicketHandler):
+
+    def subscribe_to_topic(self, topic: str, handler: Mock):
+        pass
+
+
+class TestTicketHandler:
+
+    @pytest.fixture
+    def ticket_handler(self):
+        """Fixture to create a concrete instance of TicketHandler."""
+        handler = ConcreteTicketHandler()
+        handler.location_id = 1
+        return handler
+
+    def test_on_ticket_generated(self, ticket_handler):
+        """Test that on_ticket_generated registers the correct handler."""
+        handler = ticket_handler.on_ticket_generated()
+        assert handler is not None
+
+    def test_on_ticket_called_with_counter_id(self, ticket_handler):
+        """Test that on_ticket_called registers the correct handler for counter_id."""
+        handler = ticket_handler.on_ticket_called(counter_id=124)
+        assert handler is not None
+
+    def test_on_ticket_called_with_queue_id(self, ticket_handler):
+        """Test that on_ticket_called registers the correct handler for queue_id."""
+        handler = ticket_handler.on_ticket_called(queue_id=90)
+        assert handler is not None
+
+    def test_invalid_ticket_handler_arguments(self, ticket_handler):
+        """Test the behavior when both queue_id and counter_id are provided."""
+        with pytest.raises(InvalidTicketHandlerArgumentsError):
+            ticket_handler.on_ticket_called(queue_id=90, counter_id=124)

--- a/qube/events/tests/test_ticket_handler_decorator.py
+++ b/qube/events/tests/test_ticket_handler_decorator.py
@@ -1,0 +1,124 @@
+import pytest
+import json
+from unittest.mock import Mock
+from qube.events.clients import MQTTClient
+from qube.events.exceptions import InvalidTicketHandlerArgumentsError
+from qube.events.types import AnsweringTicket, Ticket, InvalidatedBySystemEnum, StateEnum
+
+
+class TestTicketHandlerDecorator:
+    """
+    Test suite for the TicketHandlerDecorator.
+    """
+
+    @pytest.fixture
+    def mqtt_client(self):
+        """
+        Fixture to create an instance of MQTTClient.
+        """
+        return MQTTClient(api_key="dummy_api_key", location_id=1)
+
+    def create_and_send_ticket(self, mqtt_client, handler, topic, id):
+        """
+        Helper method to create and send a ticket payload to the MQTT client.
+
+        Args:
+            mqtt_client (MQTTClient): The MQTT client instance.
+            handler (Mock): The mock handler to be called.
+            topic (str): The topic to which the message is sent.
+            id (int): The ID to format the topic.
+        """
+        payload = AnsweringTicket(
+            id=1,
+            answering=2,
+            priority=True,
+            printed_tag="tag1",
+            printed_number="001",
+            number=101,
+            tags=["urgent"],
+            queue=1,
+            counter=2,
+            queue_tag="queue1",
+            counter_tag="counter1",
+            created_at='2024-01-01T00:00:00.000000Z'
+        ).__dict__
+        mqtt_client._on_message(
+            mqtt_client.client, None, Mock(topic=topic.format(id), payload=json.dumps(payload).encode('utf-8'))
+        )
+        handler.assert_called_once_with(AnsweringTicket(**payload))
+
+    def test_answering_ticket_handler_decorator_by_counter_id(self, mqtt_client):
+        """
+        Test that the handler is correctly registered and called for a specific counter ID.
+        """
+        handler = Mock()
+
+        @mqtt_client.on_ticket_called(counter_id=124)
+        def handle(msg):
+            handler(msg)
+
+        self.create_and_send_ticket(mqtt_client, handler, "locations/1/counters/{}/tickets/called", 124)
+
+    def test_answering_ticket_handler_decorator_by_queue(self, mqtt_client):
+        """
+        Test that the handler is correctly registered and called for a specific queue ID.
+        """
+        handler = Mock()
+
+        @mqtt_client.on_ticket_called(queue_id=90)
+        def handle(msg):
+            handler(msg)
+
+        self.create_and_send_ticket(mqtt_client, handler, "locations/1/queues/{}/tickets/called", 90)
+
+    def test_answering_ticket_handler_decorator_invalid_arguments(self, mqtt_client):
+        """
+        Test that providing both queue_id and counter_id raises an InvalidTicketHandlerArgumentsError.
+        """
+        with pytest.raises(InvalidTicketHandlerArgumentsError):
+
+            @mqtt_client.on_ticket_called(queue_id=90, counter_id=124)
+            def handle(msg):
+                pass
+
+    def test_on_ticket_generated(self, mqtt_client):
+        """
+        Test that the handler is correctly registered and called for ticket generated events.
+        """
+        handler = Mock()
+
+        @mqtt_client.on_ticket_generated()
+        def handle(msg):
+            handler(msg)
+
+        payload = Ticket(
+            id=12345,
+            signature="abcde12345signature",
+            number=98765,
+            printed_tag="VIP",
+            printed_number="000123",
+            note="This is a priority ticket.",
+            priority=True,
+            priority_level=1,
+            updated_at='2024-01-01T00:00:00.000000Z',
+            created_at='2024-01-01T00:00:00.000000Z',
+            state=StateEnum.END,
+            invalidated_by_system=InvalidatedBySystemEnum.INVALIDATE_RESET,
+            ticket_local_runner=101,
+            queue=5,
+            queue_dest=7,
+            counter_dest=2,
+            profile_dest=3,
+            generated_by_ticket_kiosk=99,
+            generated_by_profile=88,
+            is_generated_by_api_key=True,
+            generated_by_api_key=123456,
+            local_runner=2001,
+            tags=["urgent", "vip", "queue5"]
+        ).__dict__
+
+        mqtt_client._on_message(
+            mqtt_client.client, None,
+            Mock(topic="locations/1/tickets/generated", payload=json.dumps(payload).encode('utf-8'))
+        )
+        handler.assert_called_once_with(Ticket(**payload))

--- a/qube/events/types.py
+++ b/qube/events/types.py
@@ -1,0 +1,121 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, List, Union
+
+
+class StateEnum:
+    WAITING = 1
+    IN_SERVICE = 2
+    PAUSED = 3
+    CANCELLED = 4
+    END = 5
+
+
+class InvalidatedBySystemEnum:
+    INVALIDATE_RESET = 1
+
+
+@dataclass
+class Ticket:
+    """
+    Represents a ticket that has been generated.
+    """
+    id: int
+    signature: str
+    updated_at: datetime
+    number: int
+    printed_tag: str
+    printed_number: str
+    note: Optional[str]
+    priority: bool
+    priority_level: int
+    created_at: datetime
+    state: StateEnum
+    invalidated_by_system: Optional[Union[InvalidatedBySystemEnum, None]]
+    queue: int
+    queue_dest: int
+    ticket_local_runner: Optional[int] = None
+    counter_dest: Optional[int] = None
+    profile_dest: Optional[int] = None
+    generated_by_ticket_kiosk: Optional[int] = None
+    generated_by_profile: Optional[int] = None
+    is_generated_by_api_key: Optional[bool] = None
+    generated_by_api_key: Optional[int] = None
+    local_runner: Optional[int] = None
+    tags: List[str] = None
+
+
+@dataclass
+class QueuingSystemReset:
+    """
+    Represents a reset of the queuing system.
+    """
+    id: int
+    location: int
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class QueueGeneralDetails:
+    """
+    Represents the general details of a queue.
+    """
+    id: int
+    tag: str
+    name: str
+    kpi_wait_count: Optional[int] = None
+    kpi_wait_time: Optional[int] = None
+    kpi_service_time: Optional[int] = None
+
+
+@dataclass
+class QueueWithAverageWaitingTime:
+    """
+    Represents a Queue with an associated average waiting time.
+    """
+
+    def __init__(self, queue, average_waiting_time):
+        self.queue = queue if isinstance(queue, QueueGeneralDetails) else QueueGeneralDetails(**queue)
+        self.average_waiting_time = average_waiting_time
+
+    queue: QueueGeneralDetails
+    average_waiting_time: int
+
+
+@dataclass
+class QueueWithWaitingTickets:
+    """
+    Represents a Queue with an associated waiting ticket.
+    """
+
+    def __init__(self, queue, waiting_tickets):
+        self.queue = queue if isinstance(queue, QueueGeneralDetails) else QueueGeneralDetails(**queue)
+        self.waiting_tickets = waiting_tickets
+
+    queue: QueueGeneralDetails
+    waiting_tickets: int
+
+
+@dataclass
+class AnsweringTicket:
+    """
+    Represents a ticket that is being called in a queue or counter.
+    """
+    id: int
+    answering: int
+    priority: bool
+    printed_tag: str
+    printed_number: str
+    number: int
+    queue: int
+    counter: int
+    queue_tag: str
+    counter_tag: str
+    created_at: datetime
+    tags: Optional[List[str]] = None


### PR DESCRIPTION
- Introduced `MQTTEventHandlerBase`, for registering and managing MQTT topic handlers with payload validation and filtering.
- Added specialized handler classes with event-specific decorators:
  - `QueuingSystemResetHandler`: Includes the `@on_queuing_system_resets_created` decorator for handling reset creation events.
  - `QueueHandler`: Provides `@on_queues_changed_average_waiting_time` and `@on_queues_changed_waiting_number` decorators for handling queue events with optional queue-specific filtering.
  - `TicketHandler`: Implements `@on_ticket_generated` and `@on_ticket_called` decorators for handling ticket-related events, including validation for queue or counter-specific filters.
- Added utility methods for:
  - Payload decoding into specific types or lists of types.
  - Filtering based on queue or ticket attributes.
  - Ensuring handler uniqueness to prevent duplicate registrations.
- Implemented custom exceptions for handler registration errors, payload format/type errors, and invalid handler argument validation.

Task:[T-6341]